### PR TITLE
Fixed #10

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,7 @@ fn main() -> io::Result<()> {
         // writeln!(writer, "Processing {:#?}\nWriting results to {:#?} directory", cli.process, cli.output)?;
         writeln!(writer, "Processing {:#?}", cli.process)?;
     }
-    let palettes = match parse_palette(cli.color_palette.clone().get_json(), &cli.styles) {
+    let mut palettes = match parse_palette(cli.color_palette.clone().get_json(), &cli.styles) {
         Ok(p) => p,
         Err(err) => {
             eprintln!(
@@ -159,7 +159,7 @@ fn main() -> io::Result<()> {
         image.par_chunks_exact_mut(CHUNK).for_each(|bytes| {
             let pixel: [u8; CHUNK] = bytes.try_into().unwrap();
             let lab = Lab::from(pixel);
-            let new_rgb = lab.to_nearest_palette(&palettes).to_rgb();
+            let new_rgb = lab.to_nearest_palette(&palettes_lab).to_rgb();
             bytes[..3].copy_from_slice(&new_rgb);
         });
 

--- a/src/palettes.rs
+++ b/src/palettes.rs
@@ -5,7 +5,7 @@ use crate::cli::ColorPalette;
 impl ColorPalette {
     pub fn get_json(self) -> serde_json::Map<String, Value> {
         let colors = match self {
-            // ColorPalette::RawJSON { map } => return map,
+            ColorPalette::RawJSON { map } => return map,
             ColorPalette::Catppuccin => serde_json::from_str(include_str!("./palettes/catppuccin.json")).unwrap(),
             ColorPalette::Edge => serde_json::from_str(include_str!("./palettes/edge.json")).unwrap(),
             ColorPalette::Everforest => serde_json::from_str(include_str!("./palettes/everforest.json")).unwrap(),


### PR DESCRIPTION
- Fixed #10 
- Fix .to_nearest_palette() incorrect args
  - expected reference `&[delta::Lab]`
  - found reference `&Vec<Palette>`
- Fix non-exhaustive patterns: `ColorPalette::RawJSON { .. }` not covered
- Change palettes to mutable